### PR TITLE
Correct DARKO distance stats and rebound opportunity denominators

### DIFF
--- a/pbpstats/resources/enhanced_pbp/field_goal.py
+++ b/pbpstats/resources/enhanced_pbp/field_goal.py
@@ -433,12 +433,15 @@ class FieldGoal(object):
         bucket = self.darko_distance_bucket
         if bucket is not None:
             base_key = f"Darko_{bucket}"
-            if self.is_made:
-                key = f"{base_key}_Made"
+            made_key = f"{base_key}_Made"
+            att_key = f"{base_key}_Att"
 
-                # --- START ADDITION: Assisted/Unassisted Split ---
+            if self.is_made:
+                # Assisted / unassisted split for the scorer
                 assist_prefix = (
-                    pbpstats.ASSISTED_STRING if self.is_assisted else pbpstats.UNASSISTED_STRING
+                    pbpstats.ASSISTED_STRING
+                    if self.is_assisted
+                    else pbpstats.UNASSISTED_STRING
                 )
                 # e.g. AssistedDarko_0to3Ft or UnassistedDarko_0to3Ft
                 split_key = f"{assist_prefix}{base_key}"
@@ -450,16 +453,23 @@ class FieldGoal(object):
                         "stat_value": 1,
                     }
                 )
-                # --- END ADDITION ---
 
-            else:
-                key = f"{base_key}_Att"
+                # Made shot in this distance bucket
+                stats.append(
+                    {
+                        "player_id": self.player1_id,
+                        "team_id": self.team_id,
+                        "stat_key": made_key,
+                        "stat_value": 1,
+                    }
+                )
 
+            # Attempt in this distance bucket (always, made or missed)
             stats.append(
                 {
                     "player_id": self.player1_id,
                     "team_id": self.team_id,
-                    "stat_key": key,
+                    "stat_key": att_key,
                     "stat_value": 1,
                 }
             )

--- a/pbpstats/resources/enhanced_pbp/rebound.py
+++ b/pbpstats/resources/enhanced_pbp/rebound.py
@@ -236,12 +236,17 @@ class Rebound(object):
                             "stat_value": 1,
                         }
                         stats.append(on_floor_oreb_stat_item)
-                if isinstance(self.missed_shot, FieldGoal) and team_id == self.team_id:
-                    rebound_fga_key = (
-                        pbpstats.ON_FLOOR_OFFENSIVE_REBOUND_FGA_STRING
-                        if self.oreb
-                        else pbpstats.ON_FLOOR_DEFENSIVE_REBOUND_FGA_STRING
-                    )
+
+            # On-floor rebound *opportunity* FGAs (DARKO):
+            # every missed FG creates an offensive and defensive rebounding opportunity
+            if isinstance(self.missed_shot, FieldGoal):
+                shooting_team_id = self.missed_shot.team_id
+                for team_id, players in self.current_players.items():
+                    if team_id == shooting_team_id:
+                        rebound_fga_key = pbpstats.ON_FLOOR_OFFENSIVE_REBOUND_FGA_STRING
+                    else:
+                        rebound_fga_key = pbpstats.ON_FLOOR_DEFENSIVE_REBOUND_FGA_STRING
+
                     for player_id in players:
                         rebound_fga_stat_item = {
                             "player_id": player_id,


### PR DESCRIPTION
## Summary
- ensure DARKO distance buckets always log attempts and only increment made counts on makes while keeping assisted/unassisted splits
- record on-floor rebound FGA opportunities for both teams based on the shooting team rather than rebound outcome

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f446010348328831a7579a3de6d97)