### PR TITLE
Add team on-court shooting aggregate stats

### DIFF
--- a/pbpstats/__init__.py
+++ b/pbpstats/__init__.py
@@ -130,6 +130,14 @@ OPP_3PM_STRING = "Opp3PMOnCourt"
 OPP_FTA_STRING = "OppFTAOnCourt"
 OPP_FTM_STRING = "OppFTMOnCourt"
 
+# Team On-Court Constants
+TEAM_FGA_STRING = "TeamFGAOnCourt"
+TEAM_FGM_STRING = "TeamFGMOnCourt"
+TEAM_3PA_STRING = "Team3PAOnCourt"
+TEAM_3PM_STRING = "Team3PMOnCourt"
+TEAM_FTA_STRING = "TeamFTAOnCourt"
+TEAM_FTM_STRING = "TeamFTMOnCourt"
+
 PERSONAL_FOUL_TYPE_STRING = "Personal Fouls"
 SHOOTING_FOUL_TYPE_STRING = "Shooting Fouls"
 LOOSE_BALL_FOUL_TYPE_STRING = "Loose Ball Fouls"
@@ -380,4 +388,11 @@ KEYS_OFF_BY_FACTOR_OF_5_WHEN_AGGREGATING_FOR_TEAM_AND_LINEUPS = [
     OPP_3PM_STRING,
     OPP_FTA_STRING,
     OPP_FTM_STRING,
+    # Team on-court stats should not be over-counted when aggregating
+    TEAM_FGA_STRING,
+    TEAM_FGM_STRING,
+    TEAM_3PA_STRING,
+    TEAM_3PM_STRING,
+    TEAM_FTA_STRING,
+    TEAM_FTM_STRING,
 ]

--- a/pbpstats/resources/enhanced_pbp/field_goal.py
+++ b/pbpstats/resources/enhanced_pbp/field_goal.py
@@ -481,6 +481,48 @@ class FieldGoal(object):
 
         is_three = self.shot_value == 3
 
+        # Calculate On-Court TEAM stats (For the offense)
+        if self.team_id in self.current_players:
+            for teammate_id in self.current_players[self.team_id]:
+                stats.append(
+                    {
+                        "player_id": teammate_id,
+                        "team_id": self.team_id,
+                        "stat_key": pbpstats.TEAM_FGA_STRING,
+                        "stat_value": 1,
+                    }
+                )
+
+                if self.is_made:
+                    stats.append(
+                        {
+                            "player_id": teammate_id,
+                            "team_id": self.team_id,
+                            "stat_key": pbpstats.TEAM_FGM_STRING,
+                            "stat_value": 1,
+                        }
+                    )
+
+                if is_three:
+                    stats.append(
+                        {
+                            "player_id": teammate_id,
+                            "team_id": self.team_id,
+                            "stat_key": pbpstats.TEAM_3PA_STRING,
+                            "stat_value": 1,
+                        }
+                    )
+
+                    if self.is_made:
+                        stats.append(
+                            {
+                                "player_id": teammate_id,
+                                "team_id": self.team_id,
+                                "stat_key": pbpstats.TEAM_3PM_STRING,
+                                "stat_value": 1,
+                            }
+                        )
+
         if opponent_team_id is not None and opponent_team_id in self.current_players:
             for defender_id in self.current_players[opponent_team_id]:
                 stats.append(

--- a/pbpstats/resources/enhanced_pbp/free_throw.py
+++ b/pbpstats/resources/enhanced_pbp/free_throw.py
@@ -388,6 +388,29 @@ class FreeThrow(metaclass=abc.ABCMeta):
         team_ids = list(self.current_players.keys())
         opponent_team_candidates = [tid for tid in team_ids if tid != self.team_id]
         opponent_team_id = opponent_team_candidates[0] if opponent_team_candidates else None
+
+        # Calculate On-Court TEAM stats (For the offense)
+        if self.team_id in self.event_for_efficiency_stats.current_players:
+            for teammate_id in self.event_for_efficiency_stats.current_players[self.team_id]:
+                stats.append(
+                    {
+                        "player_id": teammate_id,
+                        "team_id": self.team_id,
+                        "stat_key": pbpstats.TEAM_FTA_STRING,
+                        "stat_value": 1,
+                    }
+                )
+
+                if self.is_made:
+                    stats.append(
+                        {
+                            "player_id": teammate_id,
+                            "team_id": self.team_id,
+                            "stat_key": pbpstats.TEAM_FTM_STRING,
+                            "stat_value": 1,
+                        }
+                    )
+
         if opponent_team_id is None:
             return self.base_stats + stats
         if opponent_team_id not in self.current_players:

--- a/tests/test_team_on_court_stats.py
+++ b/tests/test_team_on_court_stats.py
@@ -1,0 +1,119 @@
+import pbpstats
+import pytest
+from pbpstats.client import Client
+from pbpstats.resources.enhanced_pbp.field_goal import FieldGoal
+from pbpstats.resources.enhanced_pbp.free_throw import FreeThrow
+
+
+@pytest.fixture(scope="module")
+def game():
+    settings = {
+        "dir": "tests/data",
+        "EnhancedPbp": {"source": "file", "data_provider": "stats_nba"},
+        "Possessions": {"source": "file", "data_provider": "stats_nba"},
+    }
+    client = Client(settings)
+    return client.Game("0021600270")
+
+
+def _collect_on_court_totals(player_stats, player_id):
+    totals = {
+        pbpstats.TEAM_FGA_STRING: 0,
+        pbpstats.TEAM_FGM_STRING: 0,
+        pbpstats.TEAM_3PA_STRING: 0,
+        pbpstats.TEAM_3PM_STRING: 0,
+        pbpstats.TEAM_FTA_STRING: 0,
+        pbpstats.TEAM_FTM_STRING: 0,
+    }
+    for stat in player_stats:
+        if stat.get("player_id") != player_id:
+            continue
+        if stat["stat_key"] in totals:
+            totals[stat["stat_key"]] += stat["stat_value"]
+    return totals
+
+
+def _collect_personal_counts(events, player_id):
+    counts = {"fga": 0, "fg3a": 0, "fta": 0}
+    for event in events:
+        if isinstance(event, FieldGoal) and event.player1_id == player_id:
+            counts["fga"] += 1
+            if event.shot_value == 3:
+                counts["fg3a"] += 1
+        if isinstance(event, FreeThrow) and event.player1_id == player_id:
+            counts["fta"] += 1
+    return counts
+
+
+def _collect_team_box_counts(events):
+    counts = {
+        1610612760: {"fga": 0, "fg3a": 0, "fta": 0},
+        1610612764: {"fga": 0, "fg3a": 0, "fta": 0},
+    }
+    for event in events:
+        if isinstance(event, FieldGoal):
+            counts[event.team_id]["fga"] += 1
+            if event.shot_value == 3:
+                counts[event.team_id]["fg3a"] += 1
+        if isinstance(event, FreeThrow):
+            counts[event.team_id]["fta"] += 1
+    return counts
+
+
+def _lookup_team_stat(team_stats, team_id, stat_key):
+    for stat in team_stats:
+        if stat.get("team_id") == team_id and stat.get("stat_key") == stat_key:
+            return stat["stat_value"]
+    raise AssertionError(f"Missing {stat_key} for team {team_id}")
+
+
+def test_team_on_court_constants_present():
+    for const_name in [
+        "TEAM_FGA_STRING",
+        "TEAM_FGM_STRING",
+        "TEAM_3PA_STRING",
+        "TEAM_3PM_STRING",
+        "TEAM_FTA_STRING",
+        "TEAM_FTM_STRING",
+    ]:
+        assert hasattr(pbpstats, const_name)
+
+
+def test_player_team_on_court_stats_cover_personal_offense(game):
+    player_ids = [201566, 202693]
+    on_court_stats = {
+        pid: _collect_on_court_totals(game.possessions.player_stats, pid)
+        for pid in player_ids
+    }
+    personal_counts = {
+        pid: _collect_personal_counts(game.enhanced_pbp.items, pid)
+        for pid in player_ids
+    }
+
+    for pid in player_ids:
+        assert (
+            on_court_stats[pid][pbpstats.TEAM_FGA_STRING]
+            >= personal_counts[pid]["fga"]
+        )
+        assert (
+            on_court_stats[pid][pbpstats.TEAM_3PA_STRING]
+            >= personal_counts[pid]["fg3a"]
+        )
+        assert (
+            on_court_stats[pid][pbpstats.TEAM_FTA_STRING]
+            >= personal_counts[pid]["fta"]
+        )
+
+
+def test_team_on_court_totals_match_boxscore_counts(game):
+    box_counts = _collect_team_box_counts(game.enhanced_pbp.items)
+    for team_id, expected_counts in box_counts.items():
+        assert _lookup_team_stat(
+            game.possessions.team_stats, team_id, pbpstats.TEAM_FGA_STRING
+        ) == pytest.approx(expected_counts["fga"])
+        assert _lookup_team_stat(
+            game.possessions.team_stats, team_id, pbpstats.TEAM_3PA_STRING
+        ) == pytest.approx(expected_counts["fg3a"])
+        assert _lookup_team_stat(
+            game.possessions.team_stats, team_id, pbpstats.TEAM_FTA_STRING
+        ) == pytest.approx(expected_counts["fta"])


### PR DESCRIPTION
## Summary
- add team on-court shooting and free throw constants, including FGM, and include them in aggregation exclusions
- record team on-court FGA/FGM/3PA/3PM for offensive players during field goals
- track team on-court FTA/FTM for offensive players during free throws
- ensure team on-court free throw stats are recorded even when opponent splits cannot be computed
- add regression tests confirming the team on-court constants exist and lineup aggregates align with per-player and box score totals

## Testing
- PYTHONPATH=. pytest tests/test_team_on_court_stats.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6a6b5ba88328a2b5f876e472f1cb)