### PR TITLE
Document missing shot_result handling in live field goals

### DIFF
--- a/pbpstats/resources/enhanced_pbp/live/field_goal.py
+++ b/pbpstats/resources/enhanced_pbp/live/field_goal.py
@@ -37,6 +37,11 @@ class LiveFieldGoal(FieldGoal, LiveEnhancedPbpItem):
     @property
     def is_made(self):
         """
-        returns True if shot was made, False otherwise
+        returns True if shot was made, False otherwise.
+
+        Live 'heave' events (and potentially other edge cases) may not carry
+        a `shotResult` field in the raw JSON, in which case `shot_result`
+        is never set on the object. To avoid blowing up on those, treat a
+        missing shot_result as "not made".
         """
-        return self.shot_result == "Made"
+        return getattr(self, "shot_result", None) == "Made"


### PR DESCRIPTION
## Summary
- document the safe handling of missing `shot_result` on live heave events by using `getattr`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692245baa8c08328bf5acb618745381d)