### PR TITLE
Sort live enhanced play-by-play actions before building items

### DIFF
--- a/pbpstats/data_loader/live/enhanced_pbp/loader.py
+++ b/pbpstats/data_loader/live/enhanced_pbp/loader.py
@@ -40,12 +40,19 @@ class LiveEnhancedPbpLoader(LivePbpLoader, NbaEnhancedPbpLoader):
         super().__init__(game_id, source_loader)
 
     def _make_pbp_items(self):
+        actions = self.source_data["game"]["actions"]
+        actions.sort(
+            key=lambda ev: (
+                ev.get("orderNumber", 0),
+                ev.get("actionNumber", 0),
+            )
+        )
         factory = LiveEnhancedPbpFactory()
         self.items = [
             factory.get_event_class(event["actionType"], event.get("subType", ""))(
                 event, self.game_id
             )
-            for event in self.data
+            for event in actions
         ]
         self._add_extra_attrs_to_all_events()
         self._change_team_id_on_drebs()


### PR DESCRIPTION
## Summary
- sort live play-by-play actions by order and action number before constructing enhanced events to preserve chronological order

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ca1650648328b4126be5c30f569e)