### PR TITLE
Adjust live game end offense fallback

### DIFF
--- a/pbpstats/resources/enhanced_pbp/live/__init__.py
+++ b/pbpstats/resources/enhanced_pbp/live/__init__.py
@@ -4,6 +4,7 @@ from pbpstats.resources.enhanced_pbp.live.field_goal import LiveFieldGoal
 from pbpstats.resources.enhanced_pbp.live.foul import LiveFoul
 from pbpstats.resources.enhanced_pbp.live.free_throw import LiveFreeThrow
 from pbpstats.resources.enhanced_pbp.live.jump_ball import LiveJumpBall
+from pbpstats.resources.enhanced_pbp.live.game_end import LiveGameEnd
 from pbpstats.resources.enhanced_pbp.live.rebound import LiveRebound
 from pbpstats.resources.enhanced_pbp.live.replay import LiveReplay
 from pbpstats.resources.enhanced_pbp.live.start_of_period import LiveStartOfPeriod
@@ -19,6 +20,7 @@ __all__ = [
     "LiveFoul",
     "LiveFreeThrow",
     "LiveJumpBall",
+    "LiveGameEnd",
     "LiveRebound",
     "LiveReplay",
     "LiveStartOfPeriod",

--- a/pbpstats/resources/enhanced_pbp/live/game_end.py
+++ b/pbpstats/resources/enhanced_pbp/live/game_end.py
@@ -1,0 +1,16 @@
+from pbpstats.resources.enhanced_pbp.live.enhanced_pbp_item import LiveEnhancedPbpItem
+
+
+class LiveGameEnd(LiveEnhancedPbpItem):
+    """
+    Class for game end events in the live feed.
+    """
+
+    action_type = "game"
+    sub_type = "end"
+
+    def get_offense_team_id(self):
+        offense_team_id = super().get_offense_team_id()
+        if offense_team_id in (0, None) and getattr(self, "previous_event", None):
+            return self.previous_event.get_offense_team_id()
+        return offense_team_id

--- a/tests/resources/test_live_game_end.py
+++ b/tests/resources/test_live_game_end.py
@@ -1,0 +1,49 @@
+import pytest
+
+from pbpstats.resources.enhanced_pbp.live.enhanced_pbp_factory import (
+    LiveEnhancedPbpFactory,
+)
+from pbpstats.resources.enhanced_pbp.live.game_end import LiveGameEnd
+
+
+class DummyEvent:
+    def __init__(self, offense_team_id):
+        self.offense_team_id = offense_team_id
+
+    def get_offense_team_id(self):
+        return self.offense_team_id
+
+
+def build_game_end_event(**overrides):
+    item = {
+        "actionType": "game",
+        "subType": "end",
+        "clock": "PT00:00",
+        "period": 4,
+        "possession": 0,
+        "orderNumber": 1,
+    }
+    item.update(overrides)
+    return LiveGameEnd(item, "0020000001")
+
+
+def test_game_end_uses_provided_offense_team_id():
+    previous_event = DummyEvent(999)
+    game_end_event = build_game_end_event(possession=123)
+    game_end_event.previous_event = previous_event
+
+    assert game_end_event.get_offense_team_id() == 123
+
+
+def test_game_end_inherits_offense_team_id_from_previous_event_when_missing():
+    previous_event = DummyEvent(987)
+    game_end_event = build_game_end_event(possession=0)
+    game_end_event.previous_event = previous_event
+
+    assert game_end_event.get_offense_team_id() == 987
+
+
+def test_live_factory_registers_game_end_event():
+    factory = LiveEnhancedPbpFactory()
+
+    assert factory.get_event_class("game", "end") is LiveGameEnd


### PR DESCRIPTION
## Summary
- remove the redundant initializer from the live game end event
- rely on the base offense lookup before inheriting from the previous event when possession is missing

## Testing
- PYTHONPATH=. pytest tests/resources/test_live_game_end.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e3327fcc8328a8a3f64ffe374064)