### PR TITLE
Make Stats boxscore loader import lazy in start of period

### DIFF
--- a/pbpstats/resources/enhanced_pbp/stats_nba/start_of_period.py
+++ b/pbpstats/resources/enhanced_pbp/stats_nba/start_of_period.py
@@ -1,4 +1,3 @@
-from pbpstats.data_loader.stats_nba.boxscore.loader import StatsNbaBoxscoreLoader
 from pbpstats.resources.enhanced_pbp import (
     InvalidNumberOfStartersException,
     StartOfPeriod,
@@ -48,6 +47,8 @@ class StatsStartOfPeriod(StartOfPeriod, StatsEnhancedPbpItem):
         loader_obj = getattr(self, "boxscore_source_loader", None)
         if loader_obj is None:
             return None
+
+        from pbpstats.data_loader.stats_nba.boxscore.loader import StatsNbaBoxscoreLoader
 
         try:
             boxscore_loader = StatsNbaBoxscoreLoader(self.game_id, loader_obj)


### PR DESCRIPTION
## Summary
- move StatsNbaBoxscoreLoader import inside helper to avoid potential import cycles

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f31398fd08328b52c4b1951412108)