### PR TITLE
Improve offline starter fallback and shots loader stub

### DIFF
--- a/pbpstats/data_loader/__init__.py
+++ b/pbpstats/data_loader/__init__.py
@@ -55,6 +55,10 @@ from pbpstats.data_loader.stats_nba.scoreboard.file import StatsNbaScoreboardFil
 from pbpstats.data_loader.stats_nba.scoreboard.loader import StatsNbaScoreboardLoader
 from pbpstats.data_loader.stats_nba.scoreboard.web import StatsNbaScoreboardWebLoader
 from pbpstats.data_loader.stats_nba.shots.file import StatsNbaShotsFileLoader
+from pbpstats.data_loader.stats_nba.shots.local import (
+    LocalShotsJsonLoader,
+    LocalShotsJsonLoaderStub,
+)
 from pbpstats.data_loader.stats_nba.shots.loader import StatsNbaShotsLoader
 from pbpstats.data_loader.stats_nba.shots.web import StatsNbaShotsWebLoader
 
@@ -107,6 +111,8 @@ __all__ = [
     "StatsNbaScoreboardFileLoader",
     "StatsNbaScoreboardLoader",
     "StatsNbaScoreboardWebLoader",
+    "LocalShotsJsonLoader",
+    "LocalShotsJsonLoaderStub",
     "StatsNbaShotsFileLoader",
     "StatsNbaShotsLoader",
     "StatsNbaShotsWebLoader",

--- a/pbpstats/data_loader/stats_nba/shots/local.py
+++ b/pbpstats/data_loader/stats_nba/shots/local.py
@@ -1,0 +1,61 @@
+"""
+Local loaders for offline stats.nba.com shots responses.
+
+These helpers allow callers to plug cached JSON into ``StatsNbaShotsLoader``
+without making network requests.
+"""
+from pathlib import Path
+from typing import Optional, Tuple
+import json
+
+
+def load_response(game_id: str, data_type: str, file_directory: Optional[str] = None):
+    """
+    Load cached response JSON for the given game and data type.
+
+    Looks for ``<file_directory>/raw_responses/<game_id>_<data_type>.json``.
+    Returns ``None`` if the file is missing or unreadable.
+    """
+    base_dir = Path(file_directory) if file_directory else Path(".")
+    path = base_dir / "raw_responses" / f"{game_id}_{data_type}.json"
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+class LocalShotsJsonLoader:
+    """Loader for stats.nba shotchartdetail-style JSON from disk."""
+
+    def __init__(self, file_directory: Optional[str] = None):
+        self.file_directory = file_directory
+
+    def load_data(self, game_id: str) -> Tuple[dict, dict]:
+        game_id = str(game_id).zfill(10)
+        empty = {"resultSets": [{"headers": [], "rowSet": []}]}
+
+        data = load_response(game_id, "shots", self.file_directory)
+        if not data:
+            # No cached shots: treat as (home empty, away empty)
+            return empty, empty
+
+        # If the cached structure already separates home/away, return it.
+        if isinstance(data, (list, tuple)) and len(data) == 2:
+            home_data = data[0] or empty
+            away_data = data[1] or empty
+            return home_data, away_data
+
+        # Otherwise treat as combined, assign to "home", leave away empty.
+        return data, empty
+
+
+class LocalShotsJsonLoaderStub:
+    """Stub loader for shots - returns empty structure."""
+
+    def __init__(self, file_directory: Optional[str] = None):
+        self.file_directory = file_directory
+
+    def load_data(self, game_id: str) -> Tuple[dict, dict]:
+        empty = {"resultSets": [{"headers": [], "rowSet": []}]}
+        return empty, empty

--- a/pbpstats/resources/enhanced_pbp/stats_nba/start_of_period.py
+++ b/pbpstats/resources/enhanced_pbp/stats_nba/start_of_period.py
@@ -20,24 +20,33 @@ class StatsStartOfPeriod(StartOfPeriod, StatsEnhancedPbpItem):
 
     def get_period_starters(self, file_directory=None):
         """
-        Try:
-          1) PBP-based inference.
-          2) If that fails and a boxscore_source_loader is attached, use it locally.
-          3) Only if #2 is unavailable, fall back to the original stats.nba.com request.
+        Try, in order:
+          1) PBP-based inference (strict, including overrides).
+          2) Local boxscore-based starters (Period 1 via START_POSITION).
+          3) Offline best-effort PBP inference (ignore_missing_starters=True).
+          4) Legacy web fallback ONLY if no local boxscore loader was provided.
         """
+        # 1) Strict PBP-based inference
         try:
             return self._get_period_starters_from_period_events(file_directory)
         except InvalidNumberOfStartersException:
-            starters = self._get_period_starters_from_boxscore_loader()
-            if starters is not None:
-                return starters
+            pass
 
-            if getattr(self, "boxscore_source_loader", None) is not None:
-                raise InvalidNumberOfStartersException(
-                    f"Offline: Cannot determine starters for GameId: {self.game_id}, Period: {self.period}"
-                )
+        # 2) Local boxscore-based starters (Period 1)
+        starters = self._get_period_starters_from_boxscore_loader()
+        if starters is not None:
+            return starters
 
-            return self._get_starters_from_boxscore_request()
+        # 3) Offline best-effort PBP inference:
+        #    if we have a local boxscore loader, stay offline and don't crash.
+        if getattr(self, "boxscore_source_loader", None) is not None:
+            # ignore_missing_starters=True skips the strict 5-per-team assertion
+            return self._get_period_starters_from_period_events(
+                file_directory, ignore_missing_starters=True
+            )
+
+        # 4) Legacy behavior: only use web if no local loader exists at all.
+        return self._get_starters_from_boxscore_request()
 
     def _get_period_starters_from_boxscore_loader(self):
         """


### PR DESCRIPTION
## Summary
- relax stats.nba period starter inference to use best-effort offline fallbacks when a local boxscore loader is available
- add local shots JSON loader/stub that return home/away tuples for offline cached responses
- export the new local shots loaders through the data_loader package

## Testing
- python -m compileall pbpstats/resources/enhanced_pbp/stats_nba/start_of_period.py pbpstats/data_loader/stats_nba/shots/local.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f3b7794f483289a67c3c5317cbd17)