### PR TITLE
Remove Optional import from ordering

### DIFF
--- a/pbpstats/offline/__init__.py
+++ b/pbpstats/offline/__init__.py
@@ -1,0 +1,6 @@
+from pbpstats.offline.processor import PbpProcessor, get_possessions_from_df
+
+__all__ = [
+    "PbpProcessor",
+    "get_possessions_from_df",
+]

--- a/pbpstats/offline/ordering.py
+++ b/pbpstats/offline/ordering.py
@@ -1,0 +1,232 @@
+from typing import Callable, List, Dict
+import numpy as np
+import pandas as pd
+
+FetchPbpV3Fn = Callable[[str], pd.DataFrame]
+
+
+def create_raw_dicts_from_df(sorted_df: pd.DataFrame) -> List[dict]:
+    """
+    Convert a PBP DataFrame into a list of stats.nba-style event dicts.
+
+    - NaNs -> None
+    - numpy integer types -> plain Python ints
+
+    This is the canonical bridge from pandas to pbpstats' enhanced event layer.
+    """
+    items: List[dict] = []
+    records = sorted_df.to_dict("records")
+    for row in records:
+        clean_item: Dict[str, object] = {}
+        for k, v in row.items():
+            if pd.isna(v):
+                clean_item[k] = None
+            elif isinstance(v, (np.integer, np.int64)):
+                clean_item[k] = int(v)
+            else:
+                clean_item[k] = v
+        items.append(clean_item)
+    return items
+
+
+def dedupe_with_v3(
+    game_df: pd.DataFrame,
+    game_id: str,
+    fetch_pbp_v3_fn: FetchPbpV3Fn | None = None,
+) -> pd.DataFrame:
+    """
+    Filter play-by-play rows to ones present in playbyplayv3 (if available)
+    and drop duplicates.
+
+    v3 is treated as authoritative for which EVENTNUM values are "real".
+    """
+    df = game_df.copy()
+    if fetch_pbp_v3_fn is None:
+        return df.drop_duplicates(subset=["GAME_ID", "EVENTNUM"], keep="first")
+
+    df_v3 = fetch_pbp_v3_fn(game_id)
+    if df_v3.empty or "actionNumber" not in df_v3.columns:
+        return df.drop_duplicates(subset=["GAME_ID", "EVENTNUM"], keep="first")
+
+    df_v3 = df_v3.copy()
+    df_v3["actionNumber"] = pd.to_numeric(df_v3["actionNumber"], errors="coerce")
+    df_v3 = df_v3.dropna(subset=["actionNumber"])
+    valid_nums = set(df_v3["actionNumber"].astype(int).tolist())
+
+    df = df[df["EVENTNUM"].isin(valid_nums)].copy()
+    df = df.drop_duplicates(subset=["GAME_ID", "EVENTNUM"], keep="first")
+    return df
+
+
+def patch_start_of_periods(
+    game_df: pd.DataFrame,
+    game_id: str,
+    fetch_pbp_v3_fn: FetchPbpV3Fn | None = None,
+) -> pd.DataFrame:
+    """
+    Ensure there is at least one StartOfPeriod (EVENTMSGTYPE == 12) row for
+    each period present in the game.
+
+    - For Period 1, synthesize a start-of-period row if missing.
+    - For other periods, optionally use playbyplayv3 PERIOD/START markers.
+    """
+    df = game_df.copy()
+    if "EVENTMSGTYPE" not in df.columns or "PERIOD" not in df.columns:
+        return df
+
+    # Existing start-of-period markers
+    existing_periods = set(
+        df.loc[df["EVENTMSGTYPE"] == 12, "PERIOD"].dropna().astype(int).tolist()
+    )
+
+    # Ensure Q1 start exists
+    if 1 not in existing_periods and (df["PERIOD"] == 1).any():
+        cols = list(df.columns)
+        new_row: Dict[str, object] = {c: None for c in cols}
+
+        if "GAME_ID" in cols:
+            new_row["GAME_ID"] = game_id
+        if "EVENTNUM" in cols:
+            min_evnum_q1 = int(df.loc[df["PERIOD"] == 1, "EVENTNUM"].min())
+            new_row["EVENTNUM"] = min_evnum_q1 - 1
+        if "EVENTMSGTYPE" in cols:
+            new_row["EVENTMSGTYPE"] = 12
+        if "EVENTMSGACTIONTYPE" in cols:
+            new_row["EVENTMSGACTIONTYPE"] = 0
+        if "PERIOD" in cols:
+            new_row["PERIOD"] = 1
+        if "PCTIMESTRING" in cols:
+            new_row["PCTIMESTRING"] = "12:00"
+
+        for fld in [
+            "PLAYER1_ID",
+            "PLAYER1_TEAM_ID",
+            "PLAYER2_ID",
+            "PLAYER2_TEAM_ID",
+            "PLAYER3_ID",
+            "PLAYER3_TEAM_ID",
+        ]:
+            if fld in cols:
+                new_row[fld] = 0
+        if "VIDEO_AVAILABLE_FLAG" in cols:
+            new_row["VIDEO_AVAILABLE_FLAG"] = 0
+
+        df = pd.concat([pd.DataFrame([new_row]), df], ignore_index=True)
+        if "EVENTNUM" in cols:
+            df = df.sort_values(["PERIOD", "EVENTNUM"]).reset_index(drop=True)
+        existing_periods.add(1)
+
+    all_periods_in_game = set(df["PERIOD"].dropna().astype(int).unique())
+    missing_periods = all_periods_in_game - existing_periods
+
+    if not missing_periods or fetch_pbp_v3_fn is None:
+        return df
+
+    # Use v3 period/start markers if available
+    df_v3 = fetch_pbp_v3_fn(game_id)
+    if df_v3.empty or "actionType" not in df_v3.columns or "subType" not in df_v3.columns:
+        return df
+
+    mask = (
+        df_v3["actionType"].astype(str).str.lower().eq("period")
+        & df_v3["subType"].astype(str).str.lower().eq("start")
+    )
+    starts = df_v3.loc[mask]
+    if starts.empty:
+        return df
+
+    cols = list(df.columns)
+    new_rows = []
+
+    for _, r in starts.iterrows():
+        try:
+            period = int(r.get("period", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        if period <= 0 or period in existing_periods:
+            continue
+
+        action_num = r.get("actionNumber")
+        try:
+            eventnum = int(action_num)
+        except (TypeError, ValueError):
+            continue
+
+        row: Dict[str, object] = {c: None for c in cols}
+        if "GAME_ID" in cols:
+            row["GAME_ID"] = game_id
+        if "EVENTNUM" in cols:
+            row["EVENTNUM"] = eventnum
+        if "EVENTMSGTYPE" in cols:
+            row["EVENTMSGTYPE"] = 12
+        if "EVENTMSGACTIONTYPE" in cols:
+            row["EVENTMSGACTIONTYPE"] = 0
+        if "PERIOD" in cols:
+            row["PERIOD"] = period
+        if "PCTIMESTRING" in cols:
+            row["PCTIMESTRING"] = "12:00"
+
+        for fld in [
+            "PLAYER1_ID",
+            "PLAYER1_TEAM_ID",
+            "PLAYER2_ID",
+            "PLAYER2_TEAM_ID",
+            "PLAYER3_ID",
+            "PLAYER3_TEAM_ID",
+        ]:
+            if fld in cols:
+                row[fld] = 0
+
+        new_rows.append(row)
+        existing_periods.add(period)
+
+    if new_rows:
+        df_new = pd.DataFrame(new_rows, columns=cols)
+        df = pd.concat([df, df_new], ignore_index=True)
+
+    return df
+
+
+def reorder_with_v3(
+    game_df: pd.DataFrame,
+    game_id: str,
+    fetch_pbp_v3_fn: FetchPbpV3Fn,
+) -> pd.DataFrame:
+    """
+    Reorder pbp rows using playbyplayv3 actionId order.
+
+    - Build actionNumber -> canonical index mapping from v3.
+    - Sort events by that canonical index, then by EVENTNUM.
+    """
+    df_v3 = fetch_pbp_v3_fn(game_id)
+    if df_v3.empty or "actionNumber" not in df_v3.columns or "actionId" not in df_v3.columns:
+        raise RuntimeError(f"No v3 data for {game_id}")
+
+    df_v3 = df_v3.copy()
+    df_v3["actionNumber"] = pd.to_numeric(df_v3["actionNumber"], errors="coerce")
+    df_v3 = df_v3.dropna(subset=["actionNumber"])
+    df_v3["actionNumber"] = df_v3["actionNumber"].astype(int)
+    df_v3 = df_v3.sort_values("actionId")
+
+    order_map: Dict[int, int] = {}
+    canonical_idx = 0
+    for num in df_v3["actionNumber"]:
+        if num not in order_map:
+            order_map[num] = canonical_idx
+            canonical_idx += 1
+
+    result = game_df.copy()
+    result["EVENTNUM"] = pd.to_numeric(result["EVENTNUM"], errors="coerce")
+    result = result.dropna(subset=["EVENTNUM"])
+    result["EVENTNUM"] = result["EVENTNUM"].astype(int)
+
+    max_idx = len(order_map) + 1000
+    result["__v3_order"] = result["EVENTNUM"].map(order_map).fillna(max_idx).astype(int)
+
+    # Keep StartOfPeriod(1) at the very beginning if present
+    if "EVENTMSGTYPE" in result.columns and "PERIOD" in result.columns:
+        q1_start_mask = (result["EVENTMSGTYPE"] == 12) & (result["PERIOD"] == 1)
+        result.loc[q1_start_mask, "__v3_order"] = -1
+
+    result = result.sort_values(["__v3_order", "EVENTNUM"]).drop(columns="__v3_order")
+    return result

--- a/pbpstats/offline/processor.py
+++ b/pbpstats/offline/processor.py
@@ -1,0 +1,343 @@
+from typing import Callable, List, Dict, Optional
+import pandas as pd
+
+from pbpstats.data_loader.nba_enhanced_pbp_loader import NbaEnhancedPbpLoader
+from pbpstats.data_loader.nba_possession_loader import NbaPossessionLoader
+from pbpstats.resources.enhanced_pbp import Rebound
+from pbpstats.resources.enhanced_pbp.rebound import EventOrderError as ReboundEventOrderError
+from pbpstats.resources.enhanced_pbp.stats_nba.enhanced_pbp_factory import (
+    StatsNbaEnhancedPbpFactory,
+)
+from pbpstats.resources.possessions.possession import Possession
+from pbpstats.resources.possessions.possessions import Possessions
+
+from pbpstats.offline.ordering import (
+    create_raw_dicts_from_df,
+    dedupe_with_v3,
+    patch_start_of_periods,
+    reorder_with_v3,
+)
+
+FetchPbpV3Fn = Callable[[str], pd.DataFrame]
+
+# If True, the fallback in _fix_event_order will never auto-delete PLAYER rebounds.
+# It will only auto-delete TEAM/zero rebounds and will re-raise when only player
+# rebounds are candidates.
+REBOUND_STRICT_MODE: bool = True
+
+
+class PbpProcessor(NbaEnhancedPbpLoader, NbaPossessionLoader):
+    """
+    Offline processor that:
+
+      - Takes raw stats.nba-style event dicts,
+      - Builds enhanced events (lineups, score, fouls, shot clock, etc.),
+      - Repairs rebound event ordering where necessary,
+      - Splits events into Possession objects.
+
+    This wraps the core pbpstats logic (NbaEnhancedPbpLoader + NbaPossessionLoader)
+    with a robust event-order repair loop designed for parquet/offline workflows.
+    """
+
+    def __init__(
+        self,
+        game_id: str,
+        raw_data_dicts: List[dict],
+        rebound_deletions_list: Optional[List[Dict]] = None,
+    ):
+        self.game_id = str(game_id).zfill(10)
+        self.league = "nba"
+        self.file_directory = None
+        self.data = raw_data_dicts
+        self.factory = StatsNbaEnhancedPbpFactory()
+        # Per-processor log of any fallback rebound deletions
+        self._rebound_deletions_list = rebound_deletions_list
+
+        self._process_with_retries(max_retries=20)
+
+    def _build_items_from_data(self) -> None:
+        self.items = [
+            self.factory.get_event_class(item["EVENTMSGTYPE"])(item, i)
+            for i, item in enumerate(self.data)
+        ]
+
+    def _process_with_retries(self, max_retries: int) -> None:
+        attempts = 0
+        while attempts <= max_retries:
+            try:
+                # Build enhanced events
+                self._build_items_from_data()
+                self._add_extra_attrs_to_all_events()
+
+                # Force evaluation of Rebound.missed_shot so EventOrderError
+                # surfaces here instead of downstream. Using the abstract
+                # Rebound base class keeps this check stable if factories
+                # swap concrete rebound implementations.
+                for event in self.items:
+                    if isinstance(event, Rebound):
+                        _ = event.missed_shot
+
+                # Split into possessions
+                self.events = self.items
+                events_by_possession = self._split_events_by_possession()
+                self.possessions = [Possession(events) for events in events_by_possession]
+
+                # Treat possessions as "items" for NbaPossessionLoader logic
+                self.items = self.possessions
+                self._add_extra_attrs_to_all_possessions()
+                return
+
+            except ReboundEventOrderError as e:
+                if attempts == max_retries:
+                    raise ReboundEventOrderError(
+                        f"Game {self.game_id}: unable to fix rebound event order "
+                        f"after {max_retries} attempts. Last error: {e}"
+                    )
+                self._fix_event_order(e)
+                attempts += 1
+
+    def _fix_event_order(self, exception: ReboundEventOrderError) -> None:
+        """
+        Fix event ordering issues that cause ReboundEventOrderError.
+
+        This is a direct port of the custom repair logic you had in your
+        script, including pattern-based fixes and a conservative fallback
+        that may delete orphan TEAM rebounds when necessary.
+        """
+        msg = str(exception)
+        try:
+            event_num = int(msg.split("EventNum: ")[-1].split(">")[0])
+        except Exception:
+            raise exception
+
+        rows = self.data
+        issue_event_index: Optional[int] = None
+        for i, row in enumerate(rows):
+            if row.get("EVENTNUM") == event_num:
+                issue_event_index = i
+                break
+        if issue_event_index is None:
+            raise exception
+
+        def et(idx: int) -> Optional[int]:
+            if 0 <= idx < len(rows):
+                return rows[idx].get("EVENTMSGTYPE")
+            return None
+
+        def en(idx: int) -> Optional[int]:
+            if 0 <= idx < len(rows):
+                return rows[idx].get("EVENTNUM")
+            return None
+
+        # --- PATTERN 1: Previous event is sub/timeout (type 8 or 9) ---
+        if et(issue_event_index) in (8, 9):
+            row_index = issue_event_index
+            while row_index >= 0 and et(row_index) in (8, 9):
+                row_index -= 1
+
+            if row_index >= 0:
+                ft_event_num = en(row_index)
+                new_rows: List[dict] = []
+                row_to_move: Optional[dict] = None
+                for row in rows:
+                    if row.get("EVENTNUM") == ft_event_num:
+                        row_to_move = row
+                    elif row.get("EVENTNUM") == event_num:
+                        new_rows.append(row)
+                        if row_to_move is not None:
+                            new_rows.append(row_to_move)
+                    else:
+                        new_rows.append(row)
+                if row_to_move is not None:
+                    self.data = new_rows
+                    return
+
+        # --- PATTERN 2: Instant replay (type 18) before rebound ---
+        if (
+            et(issue_event_index) == 18
+            and issue_event_index + 1 < len(rows)
+            and et(issue_event_index + 1) == 4
+        ):
+            rows[issue_event_index], rows[issue_event_index + 1] = (
+                rows[issue_event_index + 1],
+                rows[issue_event_index],
+            )
+            self.data = rows
+            return
+
+        # --- PATTERN 3: Rebound immediately after, swap them ---
+        if (
+            issue_event_index + 1 < len(rows)
+            and et(issue_event_index + 1) == 4
+            and en(issue_event_index + 1) == event_num - 1
+        ):
+            rebound_event = rows[issue_event_index + 1]
+            shot_event = rows[issue_event_index]
+            rows[issue_event_index], rows[issue_event_index + 1] = (
+                rebound_event,
+                shot_event,
+            )
+            self.data = rows
+            return
+
+        # --- PATTERN 4: Shot, rebound, rebound (first rebound out of place) ---
+        if (
+            issue_event_index - 1 >= 0
+            and issue_event_index + 1 < len(rows)
+            and et(issue_event_index + 1) == 4
+            and et(issue_event_index - 1) == 2
+            and en(issue_event_index + 1) == event_num + 2
+            and en(issue_event_index - 1) == event_num + 1
+        ):
+            rebound_event = rows[issue_event_index]
+            shot_event = rows[issue_event_index - 1]
+            rows[issue_event_index - 1], rows[issue_event_index] = (
+                rebound_event,
+                shot_event,
+            )
+            self.data = rows
+            return
+
+        # --- PATTERN 5: Shot, rebound, rebound (second rebound out of place) ---
+        if (
+            issue_event_index - 1 >= 0
+            and issue_event_index + 1 < len(rows)
+            and et(issue_event_index + 1) == 4
+            and et(issue_event_index - 1) == 2
+            and en(issue_event_index + 1) == event_num - 2
+            and en(issue_event_index - 1) == event_num - 1
+        ):
+            first_rebound = rows[issue_event_index + 1]
+            second_rebound = rows[issue_event_index]
+            shot_event = rows[issue_event_index - 1]
+            rows[issue_event_index - 1 : issue_event_index + 2] = [
+                first_rebound,
+                shot_event,
+                second_rebound,
+            ]
+            self.data = rows
+            return
+
+        # --- FALLBACK: delete an orphan rebound (TEAM first, then PLAYER) ---
+        prev_period = rows[issue_event_index].get("PERIOD")
+        team_candidate_idx: Optional[int] = None
+        player_candidate_idx: Optional[int] = None
+
+        for i in range(issue_event_index + 1, min(issue_event_index + 10, len(rows))):
+            row = rows[i]
+            if row.get("PERIOD") != prev_period:
+                break
+            if et(i) != 4:  # not a rebound
+                continue
+
+            pid = row.get("PLAYER1_ID") or 0
+            # TEAM rebound: either explicit team id (16106127xx) or 0
+            is_team = pid >= 1610000000 or pid == 0
+
+            if is_team and team_candidate_idx is None:
+                team_candidate_idx = i
+                break
+
+            if (not is_team) and player_candidate_idx is None:
+                player_candidate_idx = i
+
+        def _log_deletion(deleted_row: dict, prev_evnum: int) -> None:
+            if self._rebound_deletions_list is None:
+                return
+            entry = {
+                "game_id": str(self.game_id).zfill(10),
+                "deleted_EVENTNUM": deleted_row.get("EVENTNUM"),
+                "deleted_EVENTMSGTYPE": deleted_row.get("EVENTMSGTYPE"),
+                "deleted_PERIOD": deleted_row.get("PERIOD"),
+                "deleted_PCTIMESTRING": deleted_row.get("PCTIMESTRING"),
+                "deleted_PLAYER1_ID": deleted_row.get("PLAYER1_ID"),
+                "deleted_PLAYER1_TEAM_ID": deleted_row.get("PLAYER1_TEAM_ID"),
+                "prev_EVENTNUM": prev_evnum,
+            }
+            self._rebound_deletions_list.append(entry)
+
+        # Prefer deleting a TEAM rebound if we found one
+        if team_candidate_idx is not None:
+            rebound_index = team_candidate_idx
+            deleted_row = rows[rebound_index]
+            print(
+                f"[REBOUND FIX] Game {self.game_id}: deleting TEAM orphan rebound "
+                f"EVENTNUM {en(rebound_index)} after EVENTNUM {event_num}"
+            )
+            _log_deletion(deleted_row, event_num)
+            del rows[rebound_index]
+            self.data = rows
+            return
+
+        # Only PLAYER rebounds were seen
+        if player_candidate_idx is not None:
+            rebound_index = player_candidate_idx
+            deleted_row = rows[rebound_index]
+            if REBOUND_STRICT_MODE:
+                print(
+                    f"[REBOUND FIX] Game {self.game_id}: refusing to auto-delete PLAYER rebound "
+                    f"EVENTNUM {en(rebound_index)} after EVENTNUM {event_num}; re-raising."
+                )
+                _log_deletion(deleted_row, event_num)
+                raise exception
+            else:
+                print(
+                    f"[REBOUND FIX] Game {self.game_id}: deleting PLAYER orphan rebound "
+                    f"EVENTNUM {en(rebound_index)} after EVENTNUM {event_num}"
+                )
+                _log_deletion(deleted_row, event_num)
+                del rows[rebound_index]
+                self.data = rows
+                return
+
+        # No rebound found nearby - give up and let the game fail
+        raise exception
+
+
+def get_possessions_from_df(
+    game_df: pd.DataFrame,
+    fetch_pbp_v3_fn: Optional[FetchPbpV3Fn] = None,
+    rebound_deletions_list: Optional[List[Dict]] = None,
+) -> Possessions:
+    """
+    Build a pbpstats Possessions object from a single-game PBP DataFrame.
+
+    - Optionally uses a fetch_pbp_v3_fn(game_id) -> DataFrame to:
+        * filter EVENTNUMs to those present in v3,
+        * add missing StartOfPeriod events,
+        * reorder rows by v3 actionId ordering.
+
+    - Always normalizes NaNs/ints and repairs rebound event ordering via PbpProcessor.
+    """
+    if game_df.empty:
+        raise ValueError("get_possessions_from_df: empty game_df")
+
+    game_id = str(game_df["GAME_ID"].iloc[0]).zfill(10)
+
+    df = game_df.copy()
+
+    # v3-based dedupe if available
+    df = dedupe_with_v3(df, game_id, fetch_pbp_v3_fn)
+
+    # Always drop remaining duplicates
+    df = df.drop_duplicates(subset=["GAME_ID", "EVENTNUM"], keep="first")
+
+    # Patch missing start-of-period markers
+    df = patch_start_of_periods(df, game_id, fetch_pbp_v3_fn)
+
+    # Reorder using v3 if possible; otherwise fall back to EVENTNUM / index
+    if fetch_pbp_v3_fn is not None:
+        try:
+            df_ordered = reorder_with_v3(df, game_id, fetch_pbp_v3_fn)
+        except Exception:
+            df_ordered = df.sort_values("EVENTNUM")
+    else:
+        df_ordered = df.sort_values("EVENTNUM")
+
+    # As a last fallback, preserve original order if needed
+    if df_ordered.empty:
+        df_ordered = df.sort_index()
+
+    raw_dicts = create_raw_dicts_from_df(df_ordered)
+    processor = PbpProcessor(game_id, raw_dicts, rebound_deletions_list)
+    return Possessions(processor.possessions)


### PR DESCRIPTION
## Summary
- remove the unused Optional import in the ordering helper by switching to `| None` annotations

## Testing
- python -m compileall pbpstats/offline

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7103d0c88328af85502254ba6cda)