### PR TITLE
Limit rim context to prior events

### DIFF
--- a/pbpstats/resources/enhanced_pbp/shot_clock.py
+++ b/pbpstats/resources/enhanced_pbp/shot_clock.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import List, Optional
 
 import pbpstats
@@ -10,38 +11,150 @@ from pbpstats.resources.enhanced_pbp import (
     Violation,
     Turnover,
     StartOfPeriod,
+    JumpBall,
 )
 
 
-def _safe_offense_team_id(event) -> Optional[int]:
-    """
-    Best-effort way to get the offense team id for an event.
+@dataclass(frozen=True)
+class ShotClockConfig:
+    full_reset: float = 24.0
+    short_reset: float = 14.0
+    bump_to_short_on_retained_stop: bool = True
+    hard_reset_to_short_on_rim_hit_stop: bool = True
+    treat_kicked_ball_as_retained_stop: bool = True
 
-    Uses the EnhancedPbpItem interface when available; falls back to
-    .offense_team_id if needed.
-    """
+
+def _infer_rim_hit_from_missed_shot(missed) -> Optional[bool]:
+    """Best-effort rim contact inference from the missed shot object."""
+    if missed is None:
+        return None
+
+    if isinstance(missed, FieldGoal) and getattr(missed, "is_blocked", False):
+        return False
+
+    desc = (getattr(missed, "description", "") or "").lower()
+    if "airball" in desc:
+        return False
+
+    return True
+
+
+def _infer_rim_hit_from_rebound(reb) -> Optional[bool]:
+    try:
+        missed = reb.missed_shot
+    except Exception:
+        missed = None
+    rim = _infer_rim_hit_from_missed_shot(missed)
+    if rim is not None:
+        return rim
+
+    # Fallback 1: scan same-timestamp group *before the rebound* for a missed shot
+    same_time = _events_at_same_time(reb)
+    same_time = sorted(same_time, key=lambda e: getattr(e, "order", 0))
+    try:
+        reb_idx = same_time.index(reb)
+    except ValueError:
+        reb_idx = len(same_time)
+    for ev in reversed(same_time[:reb_idx]):
+        try:
+            is_made = getattr(ev, "is_made", None)
+        except Exception:
+            is_made = None
+        if isinstance(ev, (FieldGoal, FreeThrow)) and is_made is False:
+            rim2 = _infer_rim_hit_from_missed_shot(ev)
+            if rim2 is not None:
+                return rim2
+
+    # Fallback 2: bounded backward scan within the same period/time
+    prev = getattr(reb, "previous_event", None)
+    for _ in range(6):
+        if prev is None:
+            break
+        if getattr(prev, "period", None) != getattr(reb, "period", None):
+            break
+        if getattr(prev, "seconds_remaining", None) != getattr(
+            reb, "seconds_remaining", None
+        ):
+            break
+        try:
+            is_made = getattr(prev, "is_made", None)
+        except Exception:
+            is_made = None
+        if isinstance(prev, (FieldGoal, FreeThrow)) and is_made is False:
+            rim2 = _infer_rim_hit_from_missed_shot(prev)
+            if rim2 is not None:
+                return rim2
+        prev = getattr(prev, "previous_event", None)
+
+    return None
+
+
+def _safe_is_real_rebound(ev) -> bool:
+    try:
+        return bool(getattr(ev, "is_real_rebound", False))
+    except Exception:
+        return False
+
+
+def _safe_offense_team_id(event, *, backfill_previous: bool = True) -> Optional[int]:
+    """Best-effort offense team id lookup with optional backfill to previous."""
     if event is None:
         return None
-    if hasattr(event, "get_offense_team_id"):
-        try:
+    try:
+        if hasattr(event, "get_offense_team_id"):
             tid = event.get_offense_team_id()
-        except Exception:
+        else:
             tid = getattr(event, "offense_team_id", None)
-    else:
+    except Exception:
         tid = getattr(event, "offense_team_id", None)
-    if tid == 0:
+
+    if tid in (0, None):
+        if backfill_previous:
+            prev = getattr(event, "previous_event", None)
+            if prev is not None and getattr(prev, "period", None) == getattr(
+                event, "period", None
+            ):
+                return _safe_offense_team_id(prev, backfill_previous=True)
         return None
     return tid
+
+
+def _possession_change_override(event) -> Optional[bool]:
+    if getattr(event, "possession_changing_override", False):
+        return True
+    if getattr(event, "non_possession_changing_override", False):
+        return False
+    return None
+
+
+def _infer_possession_changed(event) -> bool:
+    override = _possession_change_override(event)
+    if override is not None:
+        return override
+
+    next_event = getattr(event, "next_event", None)
+    offense_now = _safe_offense_team_id(event, backfill_previous=True)
+    offense_next = _safe_offense_team_id(next_event, backfill_previous=False)
+    if offense_now is not None and offense_next is not None:
+        return offense_now != offense_next
+
+    try:
+        if hasattr(event, "is_possession_ending_event"):
+            return bool(event.is_possession_ending_event)
+    except Exception:
+        pass
+
+    return False
 
 
 def _get_short_reset_value(league: Optional[str], season_year: Optional[int]) -> float:
     """
     Returns the shot clock value to use for short resets (offensive rebounds,
-    certain defensive fouls/violations).
+    retained-ball defensive fouls/violations).
 
     - NBA: 14s starting with 2018-19 (season_year >= 2018).
-    - WNBA / G-League: approximate as using 14s on offensive rebounds; other
-      resets are currently treated as full 24s.
+    - WNBA / G-League: approximate as 14s for the same set of retained-ball
+      situations.
     - Older NBA seasons and other leagues: no short reset; use 24s everywhere.
     """
     full = 24.0
@@ -60,6 +173,50 @@ def _get_short_reset_value(league: Optional[str], season_year: Optional[int]) ->
         return 14.0
 
     return full
+
+
+def _events_at_same_time(event) -> List[object]:
+    try:
+        if hasattr(event, "get_all_events_at_current_time"):
+            evs = event.get_all_events_at_current_time()
+            return evs or [event]
+    except Exception:
+        pass
+    return [event]
+
+
+def _rim_hit_context_at_time(event) -> bool:
+    events = _events_at_same_time(event)
+    events = sorted(events, key=lambda e: getattr(e, "order", 0))
+    cur_order = getattr(event, "order", 0)
+    prior = [e for e in events if getattr(e, "order", 0) < cur_order]
+
+    for ev in prior:
+        if isinstance(ev, Rebound) and _safe_is_real_rebound(ev):
+            rim = _infer_rim_hit_from_rebound(ev)
+            if rim is True:
+                return True
+
+    for ev in prior:
+        if isinstance(ev, FieldGoal) and not getattr(ev, "is_made", False):
+            rim = _infer_rim_hit_from_missed_shot(ev)
+            if rim is True:
+                return True
+
+    return False
+
+
+def _retained_stop_new_state(state: float, cfg: ShotClockConfig, *, rim_hit_context: bool) -> float:
+    if cfg.short_reset >= cfg.full_reset:
+        return cfg.full_reset
+
+    if cfg.hard_reset_to_short_on_rim_hit_stop and rim_hit_context:
+        return cfg.short_reset
+
+    if cfg.bump_to_short_on_retained_stop:
+        return max(cfg.short_reset, state)
+
+    return cfg.full_reset
 
 
 def annotate_shot_clock(
@@ -84,8 +241,7 @@ def annotate_shot_clock(
         return
 
     short_reset = _get_short_reset_value(league, season_year)
-    full_reset = 24.0
-    use_short_reset = short_reset < full_reset
+    cfg = ShotClockConfig(short_reset=short_reset)
 
     # Group by period to keep logic clean; events are already in chronological
     # order within a game (descending clock).
@@ -99,9 +255,7 @@ def annotate_shot_clock(
             continue
         _annotate_period_shot_clock(
             period_events,
-            full_reset=full_reset,
-            short_reset=short_reset,
-            use_short_reset=use_short_reset,
+            cfg=cfg,
             league=league,
             season_year=season_year,
         )
@@ -110,9 +264,7 @@ def annotate_shot_clock(
 def _annotate_period_shot_clock(
     period_events: List[object],
     *,
-    full_reset: float,
-    short_reset: float,
-    use_short_reset: bool,
+    cfg: ShotClockConfig,
     league: Optional[str],
     season_year: Optional[int],
 ) -> None:
@@ -124,8 +276,6 @@ def _annotate_period_shot_clock(
         return
 
     shot_clock_state: Optional[float] = None
-    last_shot_hit_rim: bool = True  # heuristic; updated on shot/FT descriptions
-
     previous_event = None
 
     # We assume events are already sorted in chronological order for the period.
@@ -133,7 +283,7 @@ def _annotate_period_shot_clock(
         # 1. Decay from previous event -> shot clock at *start* of this event.
         if previous_event is None or isinstance(ev, StartOfPeriod):
             # New period or explicit StartOfPeriod → fresh 24
-            shot_clock_state = full_reset
+            shot_clock_state = cfg.full_reset
         else:
             # Prefer clock diff over provider-specific deltas.
             prev_sec = getattr(previous_event, "seconds_remaining", None)
@@ -145,11 +295,11 @@ def _annotate_period_shot_clock(
                 dt = max(float(prev_sec) - float(cur_sec), 0.0)
 
             if shot_clock_state is None:
-                shot_clock_state = full_reset
+                shot_clock_state = cfg.full_reset
             shot_clock_state = max(shot_clock_state - dt, 0.0)
 
         # 2. Compute display shot clock (clamped by game clock).
-        raw_sc = max(0.0, min(full_reset, shot_clock_state))
+        raw_sc = max(0.0, min(cfg.full_reset, shot_clock_state))
         seconds_remaining = getattr(ev, "seconds_remaining", None)
         if seconds_remaining is not None:
             display_sc = min(raw_sc, float(seconds_remaining))
@@ -159,25 +309,18 @@ def _annotate_period_shot_clock(
         # Normalize and store; 1 decimal is usually enough.
         ev.shot_clock = round(display_sc, 1)
 
+        # Hard clamp: shot clock violations should read exactly 0.0 on the turnover.
+        if isinstance(ev, Turnover) and getattr(ev, "is_shot_clock_violation", False):
+            ev.shot_clock = 0.0
+
         # 3. Apply resets/updates caused BY this event → state for next event.
         shot_clock_state = _update_shot_clock_after_event(
             ev,
             shot_clock_state,
-            full_reset=full_reset,
-            short_reset=short_reset,
-            use_short_reset=use_short_reset,
-            league=league,
-            season_year=season_year,
-            last_shot_hit_rim=last_shot_hit_rim,
+            cfg=cfg,
+            _league=league,
+            _season_year=season_year,
         )
-
-        # 4. Update rim-hit heuristic based on this event (for future OREBs).
-        if isinstance(ev, (FieldGoal, FreeThrow)):
-            desc = getattr(ev, "description", "") or ""
-            if "airball" in desc.lower():
-                last_shot_hit_rim = False
-            else:
-                last_shot_hit_rim = True
 
         previous_event = ev
 
@@ -186,135 +329,94 @@ def _update_shot_clock_after_event(
     event,
     shot_clock_state: Optional[float],
     *,
-    full_reset: float,
-    short_reset: float,
-    use_short_reset: bool,
-    league: Optional[str],
-    season_year: Optional[int],
-    last_shot_hit_rim: bool,
+    cfg: ShotClockConfig,
+    _league: Optional[str],
+    _season_year: Optional[int],
 ) -> float:
-    """
-    Returns the shot clock value immediately AFTER `event` resolves, before any
-    time elapses to the next event.
-
-    `shot_clock_state` is the value at the *start* of this event (after decay).
-    """
     if shot_clock_state is None:
-        shot_clock_state = full_reset
+        shot_clock_state = cfg.full_reset
 
-    # Helper flags
-    is_nba_modern = (
-        league == pbpstats.NBA_STRING and season_year is not None and season_year >= 2018
-    )
-
+    possession_changed = _infer_possession_changed(event)
     offense_now = _safe_offense_team_id(event)
-    next_event = getattr(event, "next_event", None)
-    offense_next = _safe_offense_team_id(next_event)
-    offense_changed = (
-        offense_now is not None
-        and offense_next is not None
-        and offense_now != offense_next
+    team_id = getattr(event, "team_id", None)
+    is_defense_event = (
+        offense_now is not None and team_id is not None and team_id != offense_now
     )
 
-    #
-    # 1. Rebounds
-    #
-    if isinstance(event, Rebound) and event.is_real_rebound:
-        if event.oreb:
-            # Offensive rebound: offense keeps ball.
-            #
-            # If we believe the prior shot did NOT hit the rim (airball),
-            # there should be NO reset in any era; the clock keeps counting down.
-            if not last_shot_hit_rim:
+    # 0) Defensive goaltending ends the possession
+    if isinstance(event, Violation) and getattr(event, "is_goaltend_violation", False):
+        return cfg.full_reset
+
+    # 1) Rebounds
+    if isinstance(event, Rebound) and _safe_is_real_rebound(event):
+        if getattr(event, "oreb", False):
+            rim_hit = _infer_rim_hit_from_rebound(event)
+            if rim_hit is False:
                 return shot_clock_state
+            return cfg.short_reset if cfg.short_reset < cfg.full_reset else cfg.full_reset
+        return cfg.full_reset
 
-            # Otherwise, reset based on era/league rules.
-            if use_short_reset:
-                # Modern short-reset era or leagues with 14s resets
-                return short_reset
-            # Older eras: always reset to 24 on an OREB after a rim hit.
-            return full_reset
-        else:
-            # Defensive rebound: new possession → full reset.
-            return full_reset
-
-    #
-    # 2. Turnovers
-    #
-    if isinstance(event, Turnover) and not event.is_no_turnover:
-        # Any real turnover creates a new possession for the other team.
-        # We treat the reset as happening at the moment of the turnover; the
-        # decay to shots on the new possession happens via seconds_since_previous_event.
-        return full_reset
-
-    #
-    # 3. Made field goals
-    #
-    if isinstance(event, FieldGoal) and event.is_made:
-        # pbpstats already tracks "and-1 / non-possession-ending" makes.
+    # 2) Made field goals
+    if isinstance(event, FieldGoal) and getattr(event, "is_made", False):
         if getattr(event, "is_make_that_does_not_end_possession", False):
             return shot_clock_state
-        # Normal made basket → defense inbounds with fresh clock.
-        return full_reset
+        return cfg.full_reset
 
-    #
-    # 4. Free throws that end the trip
-    #
-    if isinstance(event, FreeThrow) and event.is_end_ft:
-        # If offense changes after the trip, treat this as possession end.
-        if offense_changed:
-            return full_reset
+    # 3) Turnovers
+    if isinstance(event, Turnover) and not getattr(event, "is_no_turnover", False):
+        if cfg.treat_kicked_ball_as_retained_stop and getattr(
+            event, "is_kicked_ball", False
+        ):
+            if is_defense_event and not possession_changed:
+                return _retained_stop_new_state(
+                    shot_clock_state, cfg, rim_hit_context=False
+                )
+        return cfg.full_reset
+
+    # 4) Free throws
+    if isinstance(event, FreeThrow) and getattr(event, "is_end_ft", False):
+        if possession_changed:
+            return cfg.full_reset
         return shot_clock_state
 
-    #
-    # 5. Defensive non-shooting fouls where offense keeps the ball.
-    #
+    # 5) Jump balls / held balls
+    if isinstance(event, JumpBall):
+        if possession_changed:
+            return cfg.full_reset
+        # Held-ball jump balls do not reset the shot clock when offense retains.
+        return shot_clock_state
+
+    # 6) Defensive non-shooting fouls where offense keeps the ball
     if isinstance(event, Foul):
-        # Rough "defense vs offense" check.
-        team_id = getattr(event, "team_id", None)
-        is_defense_foul = (
-            offense_now is not None and team_id is not None and team_id != offense_now
-        )
-
-        if is_defense_foul:
-            # Ignore technical/double fouls for shot clock purposes.
-            if event.is_technical or event.is_double_technical or event.is_double_foul:
+        if is_defense_event and not possession_changed:
+            if (
+                getattr(event, "is_technical", False)
+                or getattr(event, "is_double_technical", False)
+                or getattr(event, "is_double_foul", False)
+            ):
+                return shot_clock_state
+            if getattr(event, "is_shooting_foul", False) or getattr(
+                event, "is_shooting_block_foul", False
+            ):
                 return shot_clock_state
 
-            # Ignore clear shooting fouls; those are handled via FTs/rebounds.
-            if event.is_shooting_foul or event.is_shooting_block_foul:
-                return shot_clock_state
+            rim_hit_ctx = False
+            if getattr(event, "is_loose_ball_foul", False):
+                rim_hit_ctx = _rim_hit_context_at_time(event)
 
-            # Modern NBA frontcourt rule: if below 14, bump to 14; otherwise keep.
-            if is_nba_modern and use_short_reset:
-                return max(short_reset, shot_clock_state)
+            return _retained_stop_new_state(
+                shot_clock_state, cfg, rim_hit_context=rim_hit_ctx
+            )
 
-            # Other eras/leagues: treat as full reset.
-            return full_reset
-
-    #
-    # 6. Defensive violations where offense keeps ball (e.g., kicked ball)
-    #
+    # 7) Defensive violations where offense keeps the ball
     if isinstance(event, Violation):
-        team_id = getattr(event, "team_id", None)
-        is_defense_violation = (
-            offense_now is not None and team_id is not None and team_id != offense_now
-        )
+        if is_defense_event and not possession_changed:
+            return _retained_stop_new_state(
+                shot_clock_state, cfg, rim_hit_context=False
+            )
 
-        if is_defense_violation:
-            if is_nba_modern and use_short_reset:
-                return max(short_reset, shot_clock_state)
-            return full_reset
+    # 8) Fallback: possession changed
+    if possession_changed:
+        return cfg.full_reset
 
-    #
-    # 7. Fallback: offense changed but we didn't catch the specific mechanism
-    #
-    if offense_changed and not isinstance(
-        event, (FieldGoal, FreeThrow, Rebound, Turnover)
-    ):
-        return full_reset
-
-    #
-    # 8. Everything else (timeouts, subs, replay, techs, etc.) → keep current state.
-    #
     return shot_clock_state

--- a/tests/test_shot_clock.py
+++ b/tests/test_shot_clock.py
@@ -1,0 +1,327 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("."))
+
+from pbpstats.resources.enhanced_pbp.shot_clock import annotate_shot_clock
+from pbpstats.resources.enhanced_pbp import (
+    FieldGoal,
+    FreeThrow,
+    Rebound,
+    Foul,
+    Violation,
+    Turnover,
+    StartOfPeriod,
+    JumpBall,
+)
+
+
+class DummyEvent:
+    def __init__(self, *, period=1, seconds_remaining=0.0, description="", team_id=None, offense_team_id=None):
+        self.period = period
+        self.seconds_remaining = seconds_remaining
+        self.description = description
+        self.team_id = team_id
+        self.offense_team_id = offense_team_id
+        self.previous_event = None
+        self.next_event = None
+        self.order = 0
+        self._events_at_time = None
+
+    def get_offense_team_id(self):
+        return self.offense_team_id
+
+    def get_all_events_at_current_time(self):
+        return self._events_at_time or [self]
+
+
+class DummyStart(StartOfPeriod, DummyEvent):
+    def get_period_starters(self):
+        return {}
+
+    def get_offense_team_id(self):
+        return self.offense_team_id
+
+
+class DummyFG(FieldGoal, DummyEvent):
+    def __init__(self, *, is_made=False, shot_value=2, is_blocked=False, **kwargs):
+        DummyEvent.__init__(self, **kwargs)
+        self._is_made = is_made
+        self._shot_value = shot_value
+        if is_blocked:
+            self.player3_id = 1
+
+    @property
+    def is_made(self):
+        return self._is_made
+
+    @property
+    def shot_value(self):
+        return self._shot_value
+
+
+class DummyReb(Rebound, DummyEvent):
+    def __init__(self, *, is_real_rebound=True, oreb=False, missed_shot=None, **kwargs):
+        DummyEvent.__init__(self, **kwargs)
+        self._is_real_rebound = is_real_rebound
+        self._oreb = oreb
+        self._missed_shot = missed_shot
+
+    @property
+    def is_real_rebound(self):
+        return self._is_real_rebound
+
+    @property
+    def oreb(self):
+        return self._oreb
+
+    @property
+    def missed_shot(self):
+        return self._missed_shot
+
+
+class DummyTO(Turnover, DummyEvent):
+    def __init__(self, *, is_no_turnover=False, is_kicked_ball=False, is_shot_clock_violation=False, **kwargs):
+        DummyEvent.__init__(self, **kwargs)
+        self.is_no_turnover = is_no_turnover
+        self.is_kicked_ball = is_kicked_ball
+        self.is_shot_clock_violation = is_shot_clock_violation
+
+
+class DummyFoul(Foul, DummyEvent):
+    def __init__(
+        self,
+        *,
+        is_technical=False,
+        is_double_technical=False,
+        is_double_foul=False,
+        is_shooting_foul=False,
+        is_shooting_block_foul=False,
+        is_loose_ball_foul=False,
+        **kwargs,
+    ):
+        DummyEvent.__init__(self, **kwargs)
+        self._is_technical = is_technical
+        self._is_double_technical = is_double_technical
+        self._is_double_foul = is_double_foul
+        self._is_shooting_foul = is_shooting_foul
+        self._is_shooting_block_foul = is_shooting_block_foul
+        self._is_loose_ball_foul = is_loose_ball_foul
+
+    @property
+    def is_technical(self):
+        return self._is_technical
+
+    @property
+    def is_double_technical(self):
+        return self._is_double_technical
+
+    @property
+    def is_double_foul(self):
+        return self._is_double_foul
+
+    @property
+    def is_shooting_foul(self):
+        return self._is_shooting_foul
+
+    @property
+    def is_shooting_block_foul(self):
+        return self._is_shooting_block_foul
+
+    @property
+    def is_loose_ball_foul(self):
+        return self._is_loose_ball_foul
+
+
+class DummyViol(Violation, DummyEvent):
+    def __init__(self, *, is_goaltend_violation=False, **kwargs):
+        DummyEvent.__init__(self, **kwargs)
+        self.is_goaltend_violation = is_goaltend_violation
+
+
+class DummyJB(JumpBall, DummyEvent):
+    pass
+
+
+class DummyFT(FreeThrow, DummyEvent):
+    def __init__(self, *, is_end_ft=False, **kwargs):
+        DummyEvent.__init__(self, **kwargs)
+        self.is_end_ft = is_end_ft
+
+
+def _link_events(events):
+    for idx, event in enumerate(events):
+        event.order = idx
+        if idx > 0:
+            event.previous_event = events[idx - 1]
+            events[idx - 1].next_event = event
+    by_time = {}
+    for ev in events:
+        by_time.setdefault(ev.seconds_remaining, []).append(ev)
+    for group in by_time.values():
+        for ev in group:
+            ev._events_at_time = list(group)
+
+
+def test_blocked_miss_offensive_rebound_no_reset():
+    sop = DummyStart(period=1, seconds_remaining=120)
+    miss = DummyFG(
+        is_made=False,
+        description="blocked shot",
+        team_id=1,
+        offense_team_id=1,
+        seconds_remaining=100,
+        is_blocked=True,
+    )
+    oreb = DummyReb(oreb=True, missed_shot=miss, team_id=1, offense_team_id=1, seconds_remaining=100)
+    tip_in = DummyFG(is_made=True, team_id=1, offense_team_id=1, seconds_remaining=100)
+    events = [sop, miss, oreb, tip_in]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert tip_in.shot_clock == miss.shot_clock
+
+
+def test_blocked_oreb_without_missed_shot_link_still_no_reset():
+    sop = DummyStart(period=1, seconds_remaining=120)
+    miss = DummyFG(
+        is_made=False,
+        description="blocked shot",
+        team_id=1,
+        offense_team_id=1,
+        seconds_remaining=100,
+        is_blocked=True,
+    )
+    oreb = DummyReb(oreb=True, missed_shot=None, team_id=1, offense_team_id=1, seconds_remaining=100)
+    tip_in = DummyFG(is_made=True, team_id=1, offense_team_id=1, seconds_remaining=100)
+    events = [sop, miss, oreb, tip_in]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert tip_in.shot_clock == miss.shot_clock
+
+
+def test_blocked_oreb_without_link_ignores_later_miss_same_time():
+    sop = DummyStart(period=1, seconds_remaining=120)
+    miss = DummyFG(
+        is_made=False,
+        description="blocked shot",
+        team_id=1,
+        offense_team_id=1,
+        seconds_remaining=100,
+        is_blocked=True,
+    )
+    oreb = DummyReb(oreb=True, missed_shot=None, team_id=1, offense_team_id=1, seconds_remaining=100)
+    # Later miss at same timestamp (should NOT drive rim inference for the rebound)
+    putback_miss = DummyFG(is_made=False, description="miss", team_id=1, offense_team_id=1, seconds_remaining=100)
+    events = [sop, miss, oreb, putback_miss]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert putback_miss.shot_clock == miss.shot_clock
+
+
+def test_normal_miss_offensive_rebound_short_reset():
+    sop = DummyStart(period=1, seconds_remaining=120)
+    miss = DummyFG(is_made=False, description="miss", team_id=1, offense_team_id=1, seconds_remaining=100)
+    oreb = DummyReb(oreb=True, missed_shot=miss, team_id=1, offense_team_id=1, seconds_remaining=100)
+    tip_in = DummyFG(is_made=True, team_id=1, offense_team_id=1, seconds_remaining=100)
+    events = [sop, miss, oreb, tip_in]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert tip_in.shot_clock == 14.0
+
+
+def test_shot_clock_violation_display_zero():
+    sop = DummyStart(period=1, seconds_remaining=50)
+    tov = DummyTO(team_id=2, offense_team_id=1, seconds_remaining=40, is_shot_clock_violation=True)
+    events = [sop, tov]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert tov.shot_clock == 0.0
+
+
+def test_defensive_kicked_ball_retained_bumps_to_fourteen():
+    sop = DummyStart(period=1, seconds_remaining=50)
+    kicked = DummyTO(
+        team_id=2,
+        offense_team_id=1,
+        seconds_remaining=35,
+        is_kicked_ball=True,
+    )
+    next_ev = DummyFG(is_made=False, team_id=1, offense_team_id=1, seconds_remaining=30)
+    events = [sop, kicked, next_ev]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert next_ev.shot_clock == 9.0
+
+
+def test_defensive_goaltend_resets_full():
+    sop = DummyStart(period=1, seconds_remaining=50)
+    goaltend = DummyViol(team_id=2, offense_team_id=1, seconds_remaining=45, is_goaltend_violation=True)
+    next_ev = DummyFG(is_made=False, team_id=2, offense_team_id=2, seconds_remaining=44)
+    events = [sop, goaltend, next_ev]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert next_ev.shot_clock == 23.0
+
+
+def test_jump_ball_retained_does_not_reset():
+    sop = DummyStart(period=1, seconds_remaining=50)
+    jump = DummyJB(team_id=2, offense_team_id=1, seconds_remaining=35)
+    next_ev = DummyFG(is_made=False, team_id=1, offense_team_id=1, seconds_remaining=32)
+    events = [sop, jump, next_ev]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert next_ev.shot_clock == 6.0
+
+
+def test_loose_ball_foul_with_rim_context_resets_to_short():
+    sop = DummyStart(period=1, seconds_remaining=120)
+    miss = DummyFG(is_made=False, description="missed jumper", team_id=1, offense_team_id=1, seconds_remaining=118)
+    foul = DummyFoul(
+        team_id=2,
+        offense_team_id=1,
+        seconds_remaining=118,
+        is_loose_ball_foul=True,
+    )
+    next_ev = DummyFG(is_made=False, team_id=1, offense_team_id=1, seconds_remaining=117)
+    events = [sop, miss, foul, next_ev]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    assert next_ev.shot_clock == 13.0
+
+
+def test_loose_ball_foul_does_not_use_later_miss_same_timestamp_as_rim_context():
+    sop = DummyStart(period=1, seconds_remaining=50)
+    foul = DummyFoul(
+        team_id=2,
+        offense_team_id=1,
+        seconds_remaining=48,
+        is_loose_ball_foul=True,
+    )
+    # Later miss at same timestamp (should NOT create rim context for the foul)
+    late_miss = DummyFG(is_made=False, description="miss", team_id=1, offense_team_id=1, seconds_remaining=48)
+    next_ev = DummyFG(is_made=False, description="miss", team_id=1, offense_team_id=1, seconds_remaining=47)
+    events = [sop, foul, late_miss, next_ev]
+    _link_events(events)
+
+    annotate_shot_clock(events, season_year=2018, league="nba")
+
+    # If foul incorrectly hard-resets to 14, this would be 13.0 instead of 21.0
+    assert next_ev.shot_clock == 21.0


### PR DESCRIPTION
## Summary
- restrict rim-hit context inference to earlier same-timestamp events to avoid false resets on later misses
- add regression coverage for loose-ball fouls when later misses occur at the same timestamp

## Testing
- pytest tests/test_shot_clock.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694084f088a883289a80636b921fa568)