### PR TITLE
Refine carryover for missing period starters

### DIFF
--- a/pbpstats/data_loader/nba_enhanced_pbp_loader.py
+++ b/pbpstats/data_loader/nba_enhanced_pbp_loader.py
@@ -116,11 +116,14 @@ class NbaEnhancedPbpLoader(object):
                     break
             if previous_period_end_event is not None:
                 prev_players = getattr(previous_period_end_event, "current_players", None)
-                event.previous_period_end_lineups = (
-                    {team_id: list(players) for team_id, players in prev_players.items()}
-                    if isinstance(prev_players, dict)
-                    else None
-                )
+                if isinstance(prev_players, dict):
+                    snap = {}
+                    for team_id, players in prev_players.items():
+                        if isinstance(players, (list, tuple, set)):
+                            snap[team_id] = list(players)
+                    event.previous_period_end_lineups = snap or None
+                else:
+                    event.previous_period_end_lineups = None
                 event.previous_period_end_period = getattr(
                     previous_period_end_event, "period", None
                 )

--- a/pbpstats/data_loader/nba_enhanced_pbp_loader.py
+++ b/pbpstats/data_loader/nba_enhanced_pbp_loader.py
@@ -109,6 +109,12 @@ class NbaEnhancedPbpLoader(object):
             if not isinstance(event, StartOfPeriod):
                 # do no harm: only operate on true StartOfPeriod events
                 continue
+            previous_period_end_event = None
+            for j in range(i - 1, -1, -1):
+                if getattr(self.items[j], "period", None) == event.period - 1:
+                    previous_period_end_event = self.items[j]
+                    break
+            event.previous_period_end_event = previous_period_end_event
 
             team_id = event.get_team_starting_with_ball()
             event.team_starting_with_ball = team_id

--- a/pbpstats/data_loader/nba_enhanced_pbp_loader.py
+++ b/pbpstats/data_loader/nba_enhanced_pbp_loader.py
@@ -114,7 +114,19 @@ class NbaEnhancedPbpLoader(object):
                 if getattr(self.items[j], "period", None) == event.period - 1:
                     previous_period_end_event = self.items[j]
                     break
-            event.previous_period_end_event = previous_period_end_event
+            if previous_period_end_event is not None:
+                prev_players = getattr(previous_period_end_event, "current_players", None)
+                event.previous_period_end_lineups = (
+                    {team_id: list(players) for team_id, players in prev_players.items()}
+                    if isinstance(prev_players, dict)
+                    else None
+                )
+                event.previous_period_end_period = getattr(
+                    previous_period_end_event, "period", None
+                )
+            else:
+                event.previous_period_end_lineups = None
+                event.previous_period_end_period = None
 
             team_id = event.get_team_starting_with_ball()
             event.team_starting_with_ball = team_id

--- a/pbpstats/resources/enhanced_pbp/start_of_period.py
+++ b/pbpstats/resources/enhanced_pbp/start_of_period.py
@@ -304,12 +304,48 @@ class StartOfPeriod(metaclass=abc.ABCMeta):
                         f"GameId: {game_id}, Period: {self.period}, TeamId: {team_id}, Players: {starters}"
                     )
 
+    def _fill_missing_starters_from_previous_period_end(self, starters_by_team):
+        prev_end = getattr(self, "previous_period_end_event", None)
+        if prev_end is None:
+            return starters_by_team
+        if getattr(prev_end, "period", None) != self.period - 1:
+            return starters_by_team
+        prev_lineups = getattr(prev_end, "current_players", None)
+        if not isinstance(prev_lineups, dict):
+            return starters_by_team
+
+        for team_id, prev_players in prev_lineups.items():
+            if not isinstance(prev_players, list) or len(prev_players) != 5:
+                continue
+            cur = starters_by_team.get(team_id, [])
+            if not cur:
+                continue
+            if len(cur) >= 5:
+                continue
+            cur_set = set(cur)
+            prev_set = set(prev_players)
+            if cur and not cur_set.issubset(prev_set):
+                continue
+            missing = [player for player in prev_players if player not in cur_set]
+            need = 5 - len(cur)
+            if need <= 0:
+                continue
+            filled = cur + missing[:need]
+            seen = set()
+            starters_by_team[team_id] = [
+                player for player in filled if not (player in seen or seen.add(player))
+            ]
+        return starters_by_team
+
     def _get_period_starters_from_period_events(
         self, file_directory, ignore_missing_starters=False
     ):
         starters, player_team_map = self._get_players_who_started_period_with_team_map()
 
         starters_by_team = self._split_up_starters_by_team(starters, player_team_map)
+        starters_by_team = self._fill_missing_starters_from_previous_period_end(
+            starters_by_team
+        )
         if not ignore_missing_starters:
             self._check_both_teams_have_5_starters(starters_by_team, file_directory)
 

--- a/pbpstats/resources/enhanced_pbp/start_of_period.py
+++ b/pbpstats/resources/enhanced_pbp/start_of_period.py
@@ -305,13 +305,11 @@ class StartOfPeriod(metaclass=abc.ABCMeta):
                     )
 
     def _fill_missing_starters_from_previous_period_end(self, starters_by_team):
-        prev_end = getattr(self, "previous_period_end_event", None)
-        if prev_end is None:
-            return starters_by_team
-        if getattr(prev_end, "period", None) != self.period - 1:
-            return starters_by_team
-        prev_lineups = getattr(prev_end, "current_players", None)
+        prev_lineups = getattr(self, "previous_period_end_lineups", None)
         if not isinstance(prev_lineups, dict):
+            return starters_by_team
+        prev_period = getattr(self, "previous_period_end_period", None)
+        if prev_period != self.period - 1:
             return starters_by_team
 
         for team_id, prev_players in prev_lineups.items():

--- a/pbpstats/resources/enhanced_pbp/start_of_period.py
+++ b/pbpstats/resources/enhanced_pbp/start_of_period.py
@@ -324,7 +324,7 @@ class StartOfPeriod(metaclass=abc.ABCMeta):
                 continue
             cur_set = set(cur)
             prev_set = set(prev_players)
-            if cur and not cur_set.issubset(prev_set):
+            if not cur_set.issubset(prev_set):
                 continue
             missing = [player for player in prev_players if player not in cur_set]
             need = 5 - len(cur)

--- a/tests/test_period_starters_carryover.py
+++ b/tests/test_period_starters_carryover.py
@@ -9,14 +9,6 @@ TEAM_A = 100
 TEAM_B = 200
 
 
-class DummyPrevEnd:
-    period = 1
-    current_players = {
-        TEAM_A: [1, 2, 3, 4, 5],
-        TEAM_B: [11, 12, 13, 14, 15],
-    }
-
-
 class DummyStart(StartOfPeriod):
     period = 2
 
@@ -26,7 +18,11 @@ class DummyStart(StartOfPeriod):
 
 def test_fill_missing_starters_from_previous_period_end_fills_subset():
     start = DummyStart()
-    start.previous_period_end_event = DummyPrevEnd()
+    start.previous_period_end_lineups = {
+        TEAM_A: [1, 2, 3, 4, 5],
+        TEAM_B: [11, 12, 13, 14, 15],
+    }
+    start.previous_period_end_period = 1
     starters_by_team = {TEAM_A: [1, 2, 3, 4]}
 
     result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
@@ -36,7 +32,11 @@ def test_fill_missing_starters_from_previous_period_end_fills_subset():
 
 def test_fill_missing_starters_from_previous_period_end_skips_non_subset():
     start = DummyStart()
-    start.previous_period_end_event = DummyPrevEnd()
+    start.previous_period_end_lineups = {
+        TEAM_A: [1, 2, 3, 4, 5],
+        TEAM_B: [11, 12, 13, 14, 15],
+    }
+    start.previous_period_end_period = 1
     starters_by_team = {TEAM_A: [1, 2, 3, 99]}
 
     result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
@@ -46,7 +46,11 @@ def test_fill_missing_starters_from_previous_period_end_skips_non_subset():
 
 def test_fill_missing_starters_skips_when_team_not_present():
     start = DummyStart()
-    start.previous_period_end_event = DummyPrevEnd()
+    start.previous_period_end_lineups = {
+        TEAM_A: [1, 2, 3, 4, 5],
+        TEAM_B: [11, 12, 13, 14, 15],
+    }
+    start.previous_period_end_period = 1
     starters_by_team = {}
 
     result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
@@ -56,7 +60,11 @@ def test_fill_missing_starters_skips_when_team_not_present():
 
 def test_fill_missing_starters_partial_fill_multiple():
     start = DummyStart()
-    start.previous_period_end_event = DummyPrevEnd()
+    start.previous_period_end_lineups = {
+        TEAM_A: [1, 2, 3, 4, 5],
+        TEAM_B: [11, 12, 13, 14, 15],
+    }
+    start.previous_period_end_period = 1
     starters_by_team = {TEAM_A: [1, 2, 3]}
 
     result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
@@ -67,7 +75,11 @@ def test_fill_missing_starters_partial_fill_multiple():
 
 def test_fill_missing_starters_noop_when_already_5():
     start = DummyStart()
-    start.previous_period_end_event = DummyPrevEnd()
+    start.previous_period_end_lineups = {
+        TEAM_A: [1, 2, 3, 4, 5],
+        TEAM_B: [11, 12, 13, 14, 15],
+    }
+    start.previous_period_end_period = 1
     starters_by_team = {TEAM_A: [1, 2, 3, 4, 5]}
 
     result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
@@ -77,9 +89,11 @@ def test_fill_missing_starters_noop_when_already_5():
 
 def test_fill_missing_starters_noop_when_prev_period_mismatch():
     start = DummyStart()
-    prev = DummyPrevEnd()
-    prev.period = 99
-    start.previous_period_end_event = prev
+    start.previous_period_end_lineups = {
+        TEAM_A: [1, 2, 3, 4, 5],
+        TEAM_B: [11, 12, 13, 14, 15],
+    }
+    start.previous_period_end_period = 99
     starters_by_team = {TEAM_A: [1, 2, 3, 4]}
 
     result = start._fill_missing_starters_from_previous_period_end(starters_by_team)

--- a/tests/test_period_starters_carryover.py
+++ b/tests/test_period_starters_carryover.py
@@ -1,0 +1,87 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("."))
+
+from pbpstats.resources.enhanced_pbp.start_of_period import StartOfPeriod
+
+TEAM_A = 100
+TEAM_B = 200
+
+
+class DummyPrevEnd:
+    period = 1
+    current_players = {
+        TEAM_A: [1, 2, 3, 4, 5],
+        TEAM_B: [11, 12, 13, 14, 15],
+    }
+
+
+class DummyStart(StartOfPeriod):
+    period = 2
+
+    def get_period_starters(self, file_directory):
+        return {}
+
+
+def test_fill_missing_starters_from_previous_period_end_fills_subset():
+    start = DummyStart()
+    start.previous_period_end_event = DummyPrevEnd()
+    starters_by_team = {TEAM_A: [1, 2, 3, 4]}
+
+    result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
+
+    assert result[TEAM_A] == [1, 2, 3, 4, 5]
+
+
+def test_fill_missing_starters_from_previous_period_end_skips_non_subset():
+    start = DummyStart()
+    start.previous_period_end_event = DummyPrevEnd()
+    starters_by_team = {TEAM_A: [1, 2, 3, 99]}
+
+    result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
+
+    assert result[TEAM_A] == [1, 2, 3, 99]
+
+
+def test_fill_missing_starters_from_previous_period_end_fills_missing_team():
+    start = DummyStart()
+    start.previous_period_end_event = DummyPrevEnd()
+    starters_by_team = {}
+
+    result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
+
+    assert result == {}
+
+
+def test_fill_missing_starters_partial_fill_multiple():
+    start = DummyStart()
+    start.previous_period_end_event = DummyPrevEnd()
+    starters_by_team = {TEAM_A: [1, 2, 3]}
+
+    result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
+
+    assert len(result[TEAM_A]) == 5
+    assert set(result[TEAM_A]) == {1, 2, 3, 4, 5}
+
+
+def test_fill_missing_starters_noop_when_already_5():
+    start = DummyStart()
+    start.previous_period_end_event = DummyPrevEnd()
+    starters_by_team = {TEAM_A: [1, 2, 3, 4, 5]}
+
+    result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
+
+    assert result[TEAM_A] == [1, 2, 3, 4, 5]
+
+
+def test_fill_missing_starters_noop_when_prev_period_mismatch():
+    start = DummyStart()
+    prev = DummyPrevEnd()
+    prev.period = 99
+    start.previous_period_end_event = prev
+    starters_by_team = {TEAM_A: [1, 2, 3, 4]}
+
+    result = start._fill_missing_starters_from_previous_period_end(starters_by_team)
+
+    assert result[TEAM_A] == [1, 2, 3, 4]

--- a/tests/test_period_starters_carryover.py
+++ b/tests/test_period_starters_carryover.py
@@ -44,7 +44,7 @@ def test_fill_missing_starters_from_previous_period_end_skips_non_subset():
     assert result[TEAM_A] == [1, 2, 3, 99]
 
 
-def test_fill_missing_starters_from_previous_period_end_fills_missing_team():
+def test_fill_missing_starters_skips_when_team_not_present():
     start = DummyStart()
     start.previous_period_end_event = DummyPrevEnd()
     starters_by_team = {}


### PR DESCRIPTION
### Motivation
- Simplify lookup for the previous-period end event when annotating period starts to reduce redundant branching in the loader.
- Avoid constructing an entire lineup from a prior period when no starters were detected in the current period to prevent incorrect guesses on badly broken input.
- Enforce a period guard so carryover only applies when the previous event is from the exact prior period.
- Add/adjust unit tests to cover period-mismatch behavior and empty-team cases for the carryover logic.

### Description
- Simplified the previous-period end lookup in `_set_period_start_items` by always searching backwards for an event with `period == event.period - 1` and assigning `previous_period_end_event` accordingly in `pbpstats/data_loader/nba_enhanced_pbp_loader.py`.
- Added a guard `if not cur: continue` in `_fill_missing_starters_from_previous_period_end` to require at least one detected player before attempting to fill missing starters in `pbpstats/resources/enhanced_pbp/start_of_period.py`.
- Ensured `_fill_missing_starters_from_previous_period_end` respects the previous-period check and de-duplicates while preserving order when filling starters.
- Updated tests in `tests/test_period_starters_carryover.py` by adding `test_fill_missing_starters_noop_when_prev_period_mismatch`, changing the missing-team expectation to no-op, and including a `sys.path` insertion to ensure the test can import the package in the test environment.

### Testing
- Ran `pytest tests/test_period_starters_carryover.py` and all tests passed (6 passed).
- Exercised modified files: `pbpstats/data_loader/nba_enhanced_pbp_loader.py`, `pbpstats/resources/enhanced_pbp/start_of_period.py`, and `tests/test_period_starters_carryover.py`.
- No other automated test suites were modified or executed as part of this change.
- The new/adjusted tests validate subset fills, skipping non-subsets, partial fills, no-op when already five, period-mismatch no-op, and empty-team behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bbb2b822c83288b1b1de631d95952)