### PR TITLE
Fix period start substitution detection

### DIFF
--- a/pbpstats/data_loader/nba_enhanced_pbp_loader.py
+++ b/pbpstats/data_loader/nba_enhanced_pbp_loader.py
@@ -114,6 +114,16 @@ class NbaEnhancedPbpLoader(object):
                 if getattr(self.items[j], "period", None) == event.period - 1:
                     previous_period_end_event = self.items[j]
                     break
+
+            # Find the first event of this period (may be before StartOfPeriod marker
+            # due to period-start substitutions appearing first in live data)
+            first_period_event_idx = i
+            for j in range(i - 1, -1, -1):
+                if getattr(self.items[j], "period", None) == event.period:
+                    first_period_event_idx = j
+                else:
+                    break
+            event.first_period_event = self.items[first_period_event_idx]
             if previous_period_end_event is not None:
                 prev_players = getattr(previous_period_end_event, "current_players", None)
                 if isinstance(prev_players, dict):


### PR DESCRIPTION
### Motivation
- Live event feeds can include substitutions for a new period that appear before the `StartOfPeriod` marker, which broke detection because the loader set period boundary pointers such that scanning from `StartOfPeriod` or `EndOfPeriod` missed those events. 
- The change ensures period-start substitutions are found by tracking the actual first event of the period and scanning forward from that point.

### Description
- In `pbpstats/data_loader/nba_enhanced_pbp_loader.py` the loader now computes `first_period_event_idx` by scanning backwards from the `StartOfPeriod` index and assigns `event.first_period_event` so the resource can access the true first event of the period. 
- In `pbpstats/resources/enhanced_pbp/start_of_period.py` `_get_period_start_substitutions()` was rewritten to scan forward from `self.first_period_event` (fallback to `self.next_event`) to collect subs occurring exactly at period start. 
- The method now derives `start_seconds` from `self.period` and `self.league` (WNBA/regular/OT), enforces an exact-time match using a small tolerance, and ignores events without `seconds_remaining`. 
- Substitution parsing was simplified to use `incoming_player_id`/`outgoing_player_id` and to aggregate per-team `in`/`out` sets for downstream starter-filling logic.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966e77ba7ec8328947355eb4cc25665)